### PR TITLE
docs(flutter-bootstrap): add note about dummy `index.html`

### DIFF
--- a/packages/flutter_bootstrap/web/index.html
+++ b/packages/flutter_bootstrap/web/index.html
@@ -1,12 +1,16 @@
+<!-- This file is only required to make this package runnable as a standalone app -->
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <base href="$FLUTTER_BASE_HREF">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Flutter Bootstrap</title>
 </head>
+
 <body>
   <script src="flutter_bootstrap.js" async></script>
 </body>
+
 </html>


### PR DESCRIPTION
## Details

Add inline note about the required `index.html` for builds, even when it is not actually functional.