### PR TITLE
refactor(flutter-bootstrap): use empty main

### DIFF
--- a/packages/flutter_bootstrap/lib/main.dart
+++ b/packages/flutter_bootstrap/lib/main.dart
@@ -1,17 +1,1 @@
-import 'package:flutter/widgets.dart';
-
-void main() {
-  runApp(const _App());
-}
-
-class _App extends StatelessWidget {
-  const _App();
-
-  @override
-  Widget build(BuildContext context) {
-    return WidgetsApp(
-      color: const Color(0xFF000000),
-      builder: (_, __) => const SizedBox.shrink(),
-    );
-  }
-}
+void main() {}


### PR DESCRIPTION
## Details

Use empty entry point, as it is not required for builds.