### PR TITLE
fix(color-mixer-web-component): clamp color channels in setColor to reject out-of-range JS input

### DIFF
--- a/apps/color_mixer_web_component/lib/src/color_mixer_view_controller.dart
+++ b/apps/color_mixer_web_component/lib/src/color_mixer_view_controller.dart
@@ -28,7 +28,12 @@ class ColorMixerViewController extends ColorMixerController {
 
   /// Updates the current color from JS.
   void setColor(double r, double g, double b) {
-    color = Color.from(alpha: 1, red: r, green: g, blue: b);
+    color = Color.from(
+      alpha: 1,
+      red: r.clamp(0.0, 1.0),
+      green: g.clamp(0.0, 1.0),
+      blue: b.clamp(0.0, 1.0),
+    );
   }
 
   void _notifyJs() {


### PR DESCRIPTION
## Summary

- Clamps `r`, `g`, and `b` channel values to `[0.0, 1.0]` in `setColor` before constructing the `Color`, preventing out-of-range JS input from producing invalid colors.