### PR TITLE
fix(color-mixer-web-component): namespace state_ready event

### DIFF
--- a/apps/color_mixer_web_component/lib/src/color_mixer_view.dart
+++ b/apps/color_mixer_web_component/lib/src/color_mixer_view.dart
@@ -9,6 +9,9 @@ import 'package:flutter/widgets.dart';
 
 /// Stateful entry-point widget for the Color Mixer web component.
 class ColorMixerView extends StatefulWidget {
+  /// The widget name used to namespace custom events.
+  static const widgetName = 'color_mixer';
+
   /// Creates a [ColorMixerView].
   const ColorMixerView({
     super.key,

--- a/apps/color_mixer_web_component/lib/src/js_bridge.dart
+++ b/apps/color_mixer_web_component/lib/src/js_bridge.dart
@@ -2,11 +2,13 @@ import 'dart:js_interop';
 import 'dart:ui' show FlutterView;
 import 'dart:ui_web' as ui_web;
 
+import 'package:color_mixer_web_component/src/color_mixer_view.dart';
 import 'package:color_mixer_web_component/src/color_mixer_view_controller.dart';
 import 'package:web/web.dart' as web;
 
 /// Wraps [controller] as a JS interop object and dispatches
-/// `flutter::state_ready` on the view's host element.
+/// `flutter::color_mixer::color-mixer-view-controller-ready` on the view's
+/// host element.
 void dispatchColorMixerApi(
   FlutterView view,
   ColorMixerViewController controller,
@@ -15,7 +17,7 @@ void dispatchColorMixerApi(
       ui_web.views.getHostElement(view.viewId) as web.HTMLElement?;
   hostElement?.dispatchEvent(
     web.CustomEvent(
-      'flutter::state_ready',
+      'flutter::${ColorMixerView.widgetName}::color-mixer-view-controller-ready',
       web.CustomEventInit(
         detail: createJSInteropWrapper(controller),
         bubbles: false,


### PR DESCRIPTION
## Summary

- Added `static const widgetName = 'color_mixer'` to `ColorMixerView` to serve as the canonical identifier for namespacing.
- Replaced the generic `'flutter::state_ready'` event name in `js_bridge.dart` with `'flutter::color_mixer::color-mixer-view-controller-ready'`, derived from `ColorMixerView.widgetName`.
- Updated the doc comment on `dispatchColorMixerApi` to reference the new event name.