### PR TITLE
fix(tap-burst-web-component): namespace state_ready event

### DIFF
--- a/apps/tap_burst_web_component/lib/src/js_bridge.dart
+++ b/apps/tap_burst_web_component/lib/src/js_bridge.dart
@@ -2,11 +2,13 @@ import 'dart:js_interop';
 import 'dart:ui' show FlutterView;
 import 'dart:ui_web' as ui_web;
 
+import 'package:tap_burst_web_component/src/tap_burst_view.dart';
 import 'package:tap_burst_web_component/src/tap_burst_view_controller.dart';
 import 'package:web/web.dart' as web;
 
 /// Wraps [controller] as a JS interop object and dispatches
-/// `flutter::state_ready` on the view's host element.
+/// `flutter::tap_burst::tap-burst-view-controller-ready` on the view's host
+/// element.
 void dispatchTapBurstApi(
   FlutterView view,
   TapBurstViewController controller,
@@ -15,7 +17,7 @@ void dispatchTapBurstApi(
       ui_web.views.getHostElement(view.viewId) as web.HTMLElement?;
   hostElement?.dispatchEvent(
     web.CustomEvent(
-      'flutter::state_ready',
+      'flutter::${TapBurstView.widgetName}::tap-burst-view-controller-ready',
       web.CustomEventInit(
         detail: createJSInteropWrapper(controller),
         bubbles: false,

--- a/apps/tap_burst_web_component/lib/src/tap_burst_view.dart
+++ b/apps/tap_burst_web_component/lib/src/tap_burst_view.dart
@@ -9,6 +9,9 @@ import 'package:tap_burst_web_component/src/tap_burst_view_controller.dart';
 
 /// Stateful entry-point widget for the Tap Burst web component.
 class TapBurstView extends StatefulWidget {
+  /// The unique widget name used to namespace custom events.
+  static const widgetName = 'tap_burst';
+
   /// Creates a [TapBurstView].
   const TapBurstView({super.key});
 


### PR DESCRIPTION
## Summary

- Added `static const widgetName = 'tap_burst'` to `TapBurstView` to serve as the canonical identifier for namespacing.
- Replaced the generic `'flutter::state_ready'` event name in `js_bridge.dart` with `'flutter::tap_burst::tap-burst-view-controller-ready'`, derived from `TapBurstView.widgetName`.
- Updated the doc comment on `dispatchTapBurstApi` to reference the new event name.

Depends on #54.