### PR TITLE
fix(color-mixer-web-component): address lint issues

### DIFF
--- a/apps/color_mixer_web_component/lib/src/color_mixer_view.dart
+++ b/apps/color_mixer_web_component/lib/src/color_mixer_view.dart
@@ -9,13 +9,13 @@ import 'package:flutter/widgets.dart';
 
 /// Stateful entry-point widget for the Color Mixer web component.
 class ColorMixerView extends StatefulWidget {
-  /// The widget name used to namespace custom events.
-  static const widgetName = 'color_mixer';
-
   /// Creates a [ColorMixerView].
   const ColorMixerView({
     super.key,
   });
+
+  /// The widget name used to namespace custom events.
+  static const widgetName = 'color_mixer';
 
   @override
   State<ColorMixerView> createState() => _ColorMixerViewState();

--- a/apps/color_mixer_web_component/lib/src/js_bridge.dart
+++ b/apps/color_mixer_web_component/lib/src/js_bridge.dart
@@ -17,7 +17,8 @@ void dispatchColorMixerApi(
       ui_web.views.getHostElement(view.viewId) as web.HTMLElement?;
   hostElement?.dispatchEvent(
     web.CustomEvent(
-      'flutter::${ColorMixerView.widgetName}::color-mixer-view-controller-ready',
+      'flutter::${ColorMixerView.widgetName}'
+          '::color-mixer-view-controller-ready',
       web.CustomEventInit(
         detail: createJSInteropWrapper(controller),
         bubbles: false,


### PR DESCRIPTION
## Summary

- Move constructor declaration before `static const widgetName` to satisfy `sort_constructors_first`
- Break the long event name string literal across two lines to satisfy `lines_longer_than_80_chars`