### PR TITLE
fix(tap-burst-web-component): address lint issues

### DIFF
--- a/apps/tap_burst_web_component/lib/src/tap_burst_view.dart
+++ b/apps/tap_burst_web_component/lib/src/tap_burst_view.dart
@@ -9,11 +9,11 @@ import 'package:tap_burst_web_component/src/tap_burst_view_controller.dart';
 
 /// Stateful entry-point widget for the Tap Burst web component.
 class TapBurstView extends StatefulWidget {
-  /// The unique widget name used to namespace custom events.
-  static const widgetName = 'tap_burst';
-
   /// Creates a [TapBurstView].
   const TapBurstView({super.key});
+
+  /// The unique widget name used to namespace custom events.
+  static const widgetName = 'tap_burst';
 
   @override
   State<TapBurstView> createState() => _TapBurstViewState();


### PR DESCRIPTION
## Summary

- Move constructor declaration before `static const widgetName` to satisfy `sort_constructors_first`