### PR TITLE
fix(tap-burst): address lint issues

### DIFF
--- a/packages/tap_burst/lib/src/tap_burst_controller.dart
+++ b/packages/tap_burst/lib/src/tap_burst_controller.dart
@@ -8,7 +8,8 @@ class TapBurstController implements Listenable {
     Duration burstDuration = defaultBurstDuration,
   })  : particleCountNotifier =
             ValueNotifier(particleCount.asValidParticleCount),
-        burstDurationNotifier = ValueNotifier(burstDuration.asValidBurstDuration);
+        burstDurationNotifier =
+            ValueNotifier(burstDuration.asValidBurstDuration);
 
   /// Default number of particles per burst.
   static const defaultParticleCount = 10;


### PR DESCRIPTION
## Summary

- Break the long constructor initializer line across two lines to satisfy `lines_longer_than_80_chars`