### PR TITLE
test(flutter-bootstrap): add build artifact verification test

### DIFF
--- a/packages/flutter_bootstrap/.gitignore
+++ b/packages/flutter_bootstrap/.gitignore
@@ -6,3 +6,6 @@
 .pub/
 build/
 pubspec_overrides.yaml
+
+# Testing
+coverage/

--- a/packages/flutter_bootstrap/test/flutter_bootstrap_build_test.dart
+++ b/packages/flutter_bootstrap/test/flutter_bootstrap_build_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(
+    'flutter_bootstrap build artifact',
+    () {
+      final artifactFile = File(
+        '${Directory.current.path}/build/web/flutter_bootstrap.js',
+      );
+
+      setUpAll(() async {
+        final result = await Process.run(
+          'flutter',
+          ['build', 'web'],
+          runInShell: true,
+        );
+        expect(
+          result.exitCode,
+          0,
+          reason: 'flutter build web failed:\n${result.stderr}',
+        );
+      });
+
+      test('artifact file exists after build', () {
+        expect(artifactFile.existsSync(), isTrue);
+      });
+
+      test('template placeholders are replaced', () {
+        final content = artifactFile.readAsStringSync();
+        expect(content, isNot(contains('{{flutter_js}}')));
+        expect(content, isNot(contains('{{flutter_build_config}}')));
+      });
+
+      test('exposes _flutter.loader', () {
+        final content = artifactFile.readAsStringSync();
+        expect(content, contains('_flutter.loader'));
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a build artifact verification test that runs `flutter build web` and asserts the output `flutter_bootstrap.js` exists, has all template placeholders replaced, and exposes `_flutter.loader`
- Adds `coverage/` to `.gitignore` for the package

Closes #67