### PR TITLE
ci: add test.ci script and test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Analyze
         run: melos run analyze.ci
 
+      - name: Test
+        run: melos run test.ci
+
   typescript:
     name: TypeScript
     runs-on: ubuntu-latest
@@ -53,3 +56,7 @@ jobs:
       - name: Type check
         working-directory: apps/widgets_preview
         run: npm run typecheck
+
+      - name: Test
+        working-directory: apps/widgets_preview
+        run: npm run test

--- a/melos.yaml
+++ b/melos.yaml
@@ -46,3 +46,21 @@ scripts:
     description: Analyze codebase and check for analysis errors
     run: >
       dart analyze --fatal-infos --fatal-warnings .
+
+  test:
+    description: Run tests
+    run: >
+      flutter test
+    exec:
+      concurrency: 1
+    packageFilters:
+      dirExists:
+        - test
+  test.all:
+    description: Run tests for all packages
+    run: >
+      melos run --no-select test
+  test.ci:
+    description: Run tests and fail on any test error
+    run: >
+      melos exec -- flutter test


### PR DESCRIPTION
Adds Melos `test`, `test.all`, and `test.ci` scripts and extends the CI workflow to run tests sequentially after format/analyze.

## Changes

**`melos.yaml`**
- `test` — runs `flutter test` across all packages that have a `test/` directory, with concurrency 1
- `test.all` — convenience wrapper that runs `test` across all packages without prompting
- `test.ci` — CI-targeted script that runs `flutter test` via `melos exec` and fails on any error

**`.github/workflows/ci.yaml`**
- Dart job: adds a `Test` step running `melos run test.ci` after the existing `Analyze` step
- TypeScript job: adds a `Test` step running `npm run test` in `apps/widgets_preview` after the existing `Type check` step

## Related issues

- Closes #64 